### PR TITLE
Library updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 *.py[cd]
 .DS_Store
 *.egg-info

--- a/scapy2dict.py
+++ b/scapy2dict.py
@@ -4,7 +4,7 @@ from collections import ChainMap
 __all__ = ['to_dict', 'Packet2Dict']
 
 
-__version__ = '0.11'
+__version__ = '0.12'
 
 
 _native_value = (int, float, str, bytes, bool, list, tuple, set, dict, type(None))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py35, py36
+python-tag = py35, py36, py38

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
 
     # What does your project relate to?
@@ -72,7 +73,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['scapy-python3'],
+    install_requires=['scapy'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Added support for Python 3.8
Changes install requires to latest scapy library
Increased version from 0.11 to 0.12
added .vscode/ to .gitignore